### PR TITLE
Adds port as an optional input

### DIFF
--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -67,3 +67,70 @@ jobs:
       - name: All nodes joined the cluster
         run: |
           curl http://localhost:9200/_nodes/http?filter_path=nodes.*.name
+
+  run-action-custom-port:
+    name: Start Elasticsearch with custom port
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        elasticsearch: ["6.8-SNAPSHOT", "7.x-SNAPSHOT", "8.0.0-SNAPSHOT"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Start Elasticsearch
+        uses: ./elasticsearch
+        with:
+          stack-version: ${{ matrix.elasticsearch }}
+          port: 9250
+
+      - name: Elasticsearch is reachable
+        run: |
+          curl --verbose --show-error http://localhost:9250
+
+  run-multiple-nodes-custom-port:
+    name: Start multiple Elasticsearch nodes with custom ports
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        elasticsearch: ["6.8-SNAPSHOT", "7.x-SNAPSHOT", "8.0.0-SNAPSHOT"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Start Elasticsearch
+        uses: ./elasticsearch
+        with:
+          stack-version: ${{ matrix.elasticsearch }}
+          nodes: 3
+          port: 9250
+
+      - name: Elasticsearch Node es1 is reachable
+        run: |
+          curl --verbose --show-error http://localhost:9250
+
+      - name: Elasticsearch Node es2 is reachable
+        run: |
+          curl --verbose --show-error http://localhost:9251
+
+      - name: Elasticsearch Node es3 is reachable
+        run: |
+          curl --verbose --show-error http://localhost:9252
+
+      - name: All nodes joined the cluster
+        run: |
+          curl http://localhost:9250/_nodes/http?filter_path=nodes.*.name

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -13,10 +13,11 @@ ___
 
 ## Inputs
 
-| Name        | Required         | Default  | Description  |
-| ------------- |-------------| -----|-----|
-| `stack-version`     | Yes |  | The version of the Elastic Stack you need to use, you can use any version present in [docker.elastic.co](https://www.docker.elastic.co/). |
-| `nodes`     | No | 1 | Number of nodes in the cluster. |
+| Name            | Required      | Default | Description                                                                                                                               |
+| -------------   | ------------- |   ----- | -----                                                                                                                                     |
+| `stack-version` | Yes           |         | The version of the Elastic Stack you need to use, you can use any version present in [docker.elastic.co](https://www.docker.elastic.co/). |
+| `nodes`         | No            |       1 | Number of nodes in the cluster.                                                                                                           |
+| `port`          | No            |    9200 | Port where you want to run Elasticsearch.                                                                                                 |
 
 ## Usage
 

--- a/elasticsearch/action.yml
+++ b/elasticsearch/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'Number of nodes in the cluster'
     required: false
     default: 1
+  port:
+    description: 'Port where you want to run Elasticsearch'
+    required: false
+    default: 9200
 
 runs:
   using: 'docker'
@@ -21,3 +25,4 @@ runs:
   env:
     STACK_VERSION: ${{ inputs.stack-version }}
     NODES: ${{ inputs.nodes }}
+    PORT: ${{ inputs.port }}

--- a/elasticsearch/run-elasticsearch.sh
+++ b/elasticsearch/run-elasticsearch.sh
@@ -33,6 +33,7 @@ do
       --env "xpack.license.self_generated.type=basic" \
       --env "discovery.zen.ping.unicast.hosts=${UNICAST_HOSTS}" \
       --env "discovery.zen.minimum_master_nodes=${NODES}" \
+      --env "http.port=${port}" \
       --ulimit nofile=65536:65536 \
       --ulimit memlock=-1:-1 \
       --publish "${port}:${port}" \
@@ -53,6 +54,7 @@ do
       --env "ES_JAVA_OPTS=-Xms1g -Xmx1g" \
       --env "xpack.security.enabled=false" \
       --env "xpack.license.self_generated.type=basic" \
+      --env "http.port=${port}" \
       --ulimit nofile=65536:65536 \
       --ulimit memlock=-1:-1 \
       --publish "${port}:${port}" \

--- a/elasticsearch/run-elasticsearch.sh
+++ b/elasticsearch/run-elasticsearch.sh
@@ -19,7 +19,7 @@ done
 
 for (( node=1; node<=${NODES-1}; node++ ))
 do
-  port=$((9200 + $node - 1))
+  port=$((PORT + $node - 1))
   port_com=$((9300 + $node - 1))
   if [ "x${MAJOR_VERSION}" == 'x6' ]; then
     docker run \
@@ -35,8 +35,8 @@ do
       --env "discovery.zen.minimum_master_nodes=${NODES}" \
       --ulimit nofile=65536:65536 \
       --ulimit memlock=-1:-1 \
-      --publish "${port}:9200" \
-      --publish "${port_com}:9300" \
+      --publish "${port}:${port}" \
+      --publish "${port_com}:${port_com}" \
       --detach \
       --network=elastic \
       --name="es${node}" \
@@ -55,7 +55,7 @@ do
       --env "xpack.license.self_generated.type=basic" \
       --ulimit nofile=65536:65536 \
       --ulimit memlock=-1:-1 \
-      --publish "${port}:9200" \
+      --publish "${port}:${port}" \
       --detach \
       --network=elastic \
       --name="es${node}" \
@@ -73,7 +73,7 @@ docker run \
   --retry-connrefused \
   --show-error \
   --silent \
-  http://es1:9200
+  http://es1:$PORT
 
 sleep 10
 


### PR DESCRIPTION
@delvedor I added this so I can run the action on `9250` on the tests for the Ruby client to match what was used in Travis and some test commands to run a cluster in the `extensions` project. I tested it locally and it's working fine for me, but let me know if this is ok.

Update: Testing it on a PR in the Ruby client and it's not working yet...