### PR TITLE
Fix license link

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -39,4 +39,4 @@ You *must* also add the `Configure sysctl limits` step, otherwise Elasticsearch 
 
 ## License
 
-This software is licensed under the [Apache 2 license](./LICENSE).
+This software is licensed under the [Apache 2 license](../LICENSE).


### PR DESCRIPTION
It is (now?) located further up.