### PR TITLE
Fix AccessDeniedException during Elasticsearch 8 plugin installation

### DIFF
--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -162,8 +162,8 @@ jobs:
           security-enabled: false
           stack-version: ${{ matrix.elasticsearch }}
           plugins: |
-            ingest-attachment
             analysis-icu
+            analysis-kuromoji
 
       - name: Elasticsearch is reachable
         run: |

--- a/.github/workflows/elasticsearch.yml
+++ b/.github/workflows/elasticsearch.yml
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elasticsearch: [ "7.15.1" ]
+        elasticsearch: ["7.17.22", "8.14.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/enterprise-search.yml
+++ b/.github/workflows/enterprise-search.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Start Elastic Enterprise Search
         uses: ./enterprise-search
         with:
-          stack-version: 7.x-SNAPSHOT
+          stack-version: 7.17-SNAPSHOT
 
       - name: Enterprise Search is reachable
         run: |

--- a/elasticsearch/run-elasticsearch.sh
+++ b/elasticsearch/run-elasticsearch.sh
@@ -16,6 +16,7 @@ chown -R 1000:1000 /es/
 
 if [[ ! -z $PLUGINS ]]; then
   docker run --rm \
+    --user=0:0 \
     --network=elastic \
     -v /es/plugins/:/usr/share/elasticsearch/plugins/ \
     --entrypoint=/usr/share/elasticsearch/bin/elasticsearch-plugin \


### PR DESCRIPTION
Solves https://github.com/elastic/elastic-github-actions/issues/32

This Pull Request addresses an issue with the installation of plugins in Elasticsearch 8, where a `java.nio.file.AccessDeniedException` is encountered. 

