### PR TITLE
feat: make wait optional

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -20,6 +20,7 @@ ___
 | `nodes`                  | No       | 1        | Number of nodes in the cluster.                                                                                                           |
 | `port`                   | No       | 9200     | Port where you want to run Elasticsearch.                                                                                                 |
 | `elasticsearch_password` | No       | changeme | The password for the user elastic in your cluster                                                                                         |
+| `wait`                   | No       | 10       | Number of seconds to wait after launch.                                                                                         
 
 ## Usage
 

--- a/elasticsearch/action.yml
+++ b/elasticsearch/action.yml
@@ -29,7 +29,11 @@ inputs:
   plugins:
     description: 'Plugins that you want to include'
     required: false
-
+  wait:
+    description: 'Number of seconds to wait after launch'
+    required: false
+    default: 10
+    
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -40,3 +44,4 @@ runs:
     PLUGINS: ${{ inputs.plugins }}
     SECURITY_ENABLED: ${{ inputs.security-enabled }}
     ELASTICSEARCH_PASSWORD: ${{ inputs.elasticsearch_password }}
+    WAIT: ${{ inputs.wait }}

--- a/elasticsearch/run-elasticsearch.sh
+++ b/elasticsearch/run-elasticsearch.sh
@@ -156,6 +156,6 @@ else
     http://es1:$PORT
 fi
 
-sleep 10
+sleep $WAIT
 
 echo "Elasticsearch up and running"


### PR DESCRIPTION
There is a mandatory sleep in the action that might not be useful in some cases.

I just added as a parameter, so the behavior is not changed, but it can be changed with a `wait: 0`