### PR TITLE
Use `latest` Docker tag instead of `stable`

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:stable
+FROM docker:latest
 
 RUN apk add --update bash
 


### PR DESCRIPTION
This pull request updates the Docker image tag from `stable` to `latest`.

The stable tag has been [deprecated since 2020](https://hub.docker.com/_/docker#image-variants), and recent updates to GitHub runners were incompatible with this action.